### PR TITLE
SPIDR-360: Make compatible with Django 1.7-1.11, add features for O'Reilly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 target/
 
 db.sqlite3
+
+# Editor stuff
+.ctrlp

--- a/batch_requests/__init__.py
+++ b/batch_requests/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'django-batch-requests'
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 __author__ = 'Rahul Tanwani'
 __license__ = 'MIT'
 

--- a/batch_requests/concurrent/executor.py
+++ b/batch_requests/concurrent/executor.py
@@ -4,8 +4,14 @@ Created on Feb 20, 2016
 @author: Rahul Tanwani
 '''
 from abc import ABCMeta
-from concurrent.futures.thread import ThreadPoolExecutor
+
+from concurrent.futures import TimeoutError
 from concurrent.futures.process import ProcessPoolExecutor
+from concurrent.futures.thread import ThreadPoolExecutor
+
+
+def default_result_handler(future, *args, **kwargs):
+    return future.result()
 
 
 class Executor(object):
@@ -14,13 +20,31 @@ class Executor(object):
     '''
     __metaclass__ = ABCMeta
 
-    def execute(self, requests, resp_generator, *args, **kwargs):
+    def __init__(self, num_workers, timeout=None):
+        '''
+            Create a thread pool for concurrent execution with specified number of workers.
+        '''
+        self.num_workers = num_workers
+        self.timeout = timeout
+
+    def get_executor_pool(self, num_workers=None):
+        return self.executor_cls(num_workers or self.num_workers)
+
+    def execute(self, requests, resp_generator,
+                result_handler=default_result_handler,
+                *args, **kwargs):
         '''
             Calls the resp_generator for all the requests in parallel in an asynchronous way.
         '''
-        result_futures = [self.executor_pool.submit(resp_generator, req, *args, **kwargs) for req in requests]
-        resp = [res_future.result() for res_future in result_futures]
-        return resp
+        pool = self.get_executor_pool()
+        timeout = self.timeout
+        return [
+            # future.result() for future in [
+            result_handler(future, timeout) for future in [
+                pool.submit(resp_generator, req, *args, **kwargs)
+                for req in requests
+            ]
+        ]
 
 
 class SequentialExecutor(Executor):
@@ -39,19 +63,11 @@ class ThreadBasedExecutor(Executor):
     '''
         An implementation of executor using threads for parallelism.
     '''
-    def __init__(self, num_workers):
-        '''
-            Create a thread pool for concurrent execution with specified number of workers.
-        '''
-        self.executor_pool = ThreadPoolExecutor(num_workers)
+    executor_cls = ThreadPoolExecutor
 
 
 class ProcessBasedExecutor(Executor):
     '''
         An implementation of executor using process(es) for parallelism.
     '''
-    def __init__(self, num_workers):
-        '''
-            Create a process pool for concurrent execution with specified number of workers.
-        '''
-        self.executor_pool = ProcessPoolExecutor(num_workers)
+    executor_cls = ProcessPoolExecutor

--- a/batch_requests/concurrent/executor.py
+++ b/batch_requests/concurrent/executor.py
@@ -39,7 +39,6 @@ class Executor(object):
         pool = self.get_executor_pool()
         timeout = self.timeout
         return [
-            # future.result() for future in [
             result_handler(future, timeout) for future in [
                 pool.submit(resp_generator, req, *args, **kwargs)
                 for req in requests

--- a/batch_requests/concurrent/executor.py
+++ b/batch_requests/concurrent/executor.py
@@ -3,9 +3,10 @@ Created on Feb 20, 2016
 
 @author: Rahul Tanwani
 '''
+from __future__ import absolute_import, unicode_literals
+
 from abc import ABCMeta
 
-from concurrent.futures import TimeoutError
 from concurrent.futures.process import ProcessPoolExecutor
 from concurrent.futures.thread import ThreadPoolExecutor
 

--- a/batch_requests/exceptions.py
+++ b/batch_requests/exceptions.py
@@ -5,6 +5,7 @@ Created on Dec 30, 2014
 
 @summary: Holds exception required for batch_requests app.
 '''
+from __future__ import unicode_literals
 
 
 class BadBatchRequest(Exception):

--- a/batch_requests/settings.py
+++ b/batch_requests/settings.py
@@ -3,21 +3,33 @@
 
 @summary: Contains the default settings.
 '''
-
-from django.conf import settings
-from django.utils.importlib import import_module
 import multiprocessing
 
+import six
+from django.conf import settings
+
+try:
+    from django.utils.importlib import import_module
+except ImportError:
+    from importlib import import_module
+
 DEFAULTS = {
-    "HEADERS_TO_INCLUDE": ["HTTP_USER_AGENT", "HTTP_COOKIE"],
-    "DEFAULT_CONTENT_TYPE": "application/json",
-    "USE_HTTPS": False,
-    "EXECUTE_PARALLEL": False,
-    "CONCURRENT_EXECUTOR": "batch_requests.concurrent.executor.ThreadBasedExecutor",
-    "NUM_WORKERS": multiprocessing.cpu_count() * 4,
     "ADD_DURATION_HEADER": True,
+    "BATCH_RESPONSE_STATUS": 200,
+    "CONCURRENT_EXECUTOR": "batch_requests.concurrent.executor.ThreadBasedExecutor",
+    "DEBUG_HEADER_NAME": "batch_requests.debug",
+    "DEFAULT_CONTENT_TYPE": "application/json",
+    "DISALLOW_CACHING": False,
     "DURATION_HEADER_NAME": "batch_requests.duration",
-    "MAX_LIMIT": 20
+    "EXECUTE_PARALLEL": False,
+    "HEADERS_TO_INCLUDE": {"HTTP_USER_AGENT", "HTTP_COOKIE"},
+    "NUM_WORKERS": multiprocessing.cpu_count() * 4,
+    "MAX_LIMIT": 20,
+    "REQUEST_TIMEOUT": None,
+    "USE_HTTPS": False,
+
+    # JN: added for ORM use
+    "DESERIALIZE_RESPONSES": False,
 }
 
 
@@ -49,33 +61,29 @@ class BatchRequestSettings(object):
         '''
             Creating an ExecutorPool is a costly operation. Executor needs to be instantiated only once.
         '''
-        if self.EXECUTE_PARALLEL is False:
-            executor_path = "batch_requests.concurrent.executor.SequentialExecutor"
-            executor_class = import_class(executor_path)
-            return executor_class()
-        else:
+        executor_path = "batch_requests.concurrent.executor.SequentialExecutor"
+        if self.EXECUTE_PARALLEL:
             executor_path = self.CONCURRENT_EXECUTOR
-            executor_class = import_class(executor_path)
-            return executor_class(self.NUM_WORKERS)
+
+        executor_class = import_class(executor_path)
+        return executor_class(self.NUM_WORKERS, self.REQUEST_TIMEOUT)
 
     def __getattr__(self, attr):
         '''
             Override the attribute access behavior.
         '''
 
-        if attr not in self.defaults.keys():
+        if attr not in self.defaults:
             raise AttributeError("Invalid API setting: '%s'" % attr)
 
-        try:
-            # Check if present in user settings
-            val = self.user_settings[attr]
-        except KeyError:
-            # Fall back to defaults
-            val = self.defaults[attr]
+        val = self.user_settings.get(attr, self.defaults[attr])
 
         # Cache the result
         setattr(self, attr, val)
         return val
+
+    def as_dict(self):
+        return {k: getattr(self, k) for k in six.iterkeys(self.defaults)}
 
 
 br_settings = BatchRequestSettings(USER_DEFINED_SETTINGS, DEFAULTS)

--- a/batch_requests/views.py
+++ b/batch_requests/views.py
@@ -3,20 +3,96 @@
 
 @summary: A module to perform batch request processing.
 '''
+from __future__ import absolute_import, unicode_literals
 
 import json
+import logging
+from datetime import datetime
 
-from django.core.urlresolvers import resolve
-from django.http.response import HttpResponse, HttpResponseBadRequest,\
-    HttpResponseServerError
+import six
+from django.conf import settings
+from django.http.response import (
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseNotFound,
+    HttpResponseServerError,
+)
 from django.template.response import ContentNotRenderedError
+from django.urls import resolve
+from django.urls.exceptions import Resolver404
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
+from batch_requests.concurrent.executor import TimeoutError
 from batch_requests.exceptions import BadBatchRequest
 from batch_requests.settings import br_settings as _settings
 from batch_requests.utils import get_wsgi_request_object
-from datetime import datetime
+
+
+log = logging.getLogger(__name__)
+
+
+DURATION_HEADER_NAME = _settings.DURATION_HEADER_NAME
+UNKNOWN_STATUSES = {
+    207: "Multiple Statuses",
+    429: "Too Many Requests",
+}
+VALID_HTTP_METHODS = {
+    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+    "CONNECT", "TRACE"
+}
+
+
+class BytesEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, six.binary_type):
+            return obj.decode("utf-8")
+
+        return super(BytesEncoder, self).default(obj)
+
+
+class SetEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (set, frozenset)):
+            return list(obj)
+
+        return super(SetEncoder, self).default(obj)
+
+
+def timeout_result_handler(future, timeout=None):
+    """Allow timing out concurrent requests"""
+
+    try:
+        result = future.result(timeout=timeout)
+    except TimeoutError:
+        result = {
+            "status_code": 408,
+            "reason_phrase": "Request Timeout",
+            "body": "",
+            "headers": {},
+        }
+
+    return result
+
+
+def handle_sub_response_body(response):
+    body = getattr(response, "rendered_content", None) or response.content
+    if body and _settings.DESERIALIZE_RESPONSES:
+        return json.loads(body)
+
+    return body
+
+
+def handle_sub_reason_phrase(response, unknown=UNKNOWN_STATUSES):
+    phrase = unknown.get(response.status_code, None)
+    if phrase:
+        return phrase
+
+    return response.reason_phrase
+
+
+def construct_duration_header(duration):
+    return duration.seconds + (duration.microseconds / 1000000.0)
 
 
 def get_response(wsgi_request):
@@ -24,31 +100,35 @@ def get_response(wsgi_request):
         Given a WSGI request, makes a call to a corresponding view
         function and returns the response.
     '''
+    resp = None
     service_start_time = datetime.now()
     # Get the view / handler for this request
-    view, args, kwargs = resolve(wsgi_request.path_info)
-
-    kwargs.update({"request": wsgi_request})
-
-    # Let the view do his task.
     try:
-        resp = view(*args, **kwargs)
-    except Exception as exc:
-        resp = HttpResponseServerError(content=exc.message)
+        view, args, kwargs = resolve(wsgi_request.path_info)
+    except Resolver404 as exc:
+        resp = HttpResponseNotFound()
 
-    headers = dict(resp._headers.values())
+    if resp is None:
+        kwargs.update({"request": wsgi_request})
+
+        # Let the view do his task.
+        try:
+            resp = view(*args, **kwargs)
+        except Exception as exc:
+            resp = HttpResponseServerError(content=str(exc))
+
     # Convert HTTP response into simple dict type.
-    d_resp = {"status_code": resp.status_code, "reason_phrase": resp.reason_phrase,
-              "headers": headers}
-    try:
-        d_resp.update({"body": resp.content})
-    except ContentNotRenderedError:
-        resp.render()
-        d_resp.update({"body": resp.content})
+    d_resp = {
+        "status_code": resp.status_code,
+        "reason_phrase": handle_sub_reason_phrase(resp),
+        "headers": {k:v for k, v in six.itervalues(resp._headers)},
+        "body": handle_sub_response_body(resp),
+    }
 
     # Check if we need to send across the duration header.
     if _settings.ADD_DURATION_HEADER:
-        d_resp['headers'].update({_settings.DURATION_HEADER_NAME: (datetime.now() - service_start_time).seconds})
+        duration = datetime.now() - service_start_time
+        d_resp["headers"][DURATION_HEADER_NAME] = construct_duration_header(duration)
 
     return d_resp
 
@@ -58,22 +138,19 @@ def get_wsgi_requests(request):
         For the given batch request, extract the individual requests and create
         WSGIRequest object for each.
     '''
-    valid_http_methods = ["get", "post", "put", "patch", "delete", "head", "options", "connect", "trace"]
-    requests = json.loads(request.body)
+    body = request.body.decode('utf-8')
+    requests = json.loads(body)
 
-    if type(requests) not in (list, tuple):
+    if not isinstance(requests, (list, tuple)):
         raise BadBatchRequest("The body of batch request should always be list!")
 
-    # Max limit check.
-    no_requests = len(requests)
-
-    if no_requests > _settings.MAX_LIMIT:
+    if len(requests) > _settings.MAX_LIMIT:
         raise BadBatchRequest("You can batch maximum of %d requests." % (_settings.MAX_LIMIT))
 
-    # We could mutate the current request with the respective parameters, but mutation is ghost in the dark,
-    # so lets avoid. Construct the new WSGI request object for each request.
-
-    def construct_wsgi_from_data(data):
+    # We could mutate the current request with the respective parameters, but
+    # mutation is ghost in the dark, so lets avoid. Construct the new WSGI
+    # request object for each request.
+    def construct_wsgi_from_data(data, valid_http_methods=VALID_HTTP_METHODS):
         '''
             Given the data in the format of url, method, body and headers, construct a new
             WSGIRequest object.
@@ -84,14 +161,18 @@ def get_wsgi_requests(request):
         if url is None or method is None:
             raise BadBatchRequest("Request definition should have url, method defined.")
 
-        if method.lower() not in valid_http_methods:
+        method = method.upper()
+        if method not in valid_http_methods:
             raise BadBatchRequest("Invalid request method.")
 
+        # support singly/doubly encoded JSON
         body = data.get("body", "")
+        if isinstance(body, dict):
+            body = json.dumps(body, cls=BytesEncoder)
         headers = data.get("headers", {})
         return get_wsgi_request_object(request, method, url, headers, body)
 
-    return [construct_wsgi_from_data(data) for data in requests]
+    return (construct_wsgi_from_data(data) for data in requests)
 
 
 def execute_requests(wsgi_requests):
@@ -100,7 +181,9 @@ def execute_requests(wsgi_requests):
         execution setting.
     '''
     executor = _settings.executor
-    return executor.execute(wsgi_requests, get_response)
+    return executor.execute(
+        wsgi_requests, get_response, result_handler=timeout_result_handler
+    )
 
 
 @csrf_exempt
@@ -109,20 +192,43 @@ def handle_batch_requests(request, *args, **kwargs):
     '''
         A view function to handle the overall processing of batch requests.
     '''
-    batch_start_time = datetime.now()
     try:
         # Get the Individual WSGI requests.
         wsgi_requests = get_wsgi_requests(request)
     except BadBatchRequest as brx:
-        return HttpResponseBadRequest(content=brx.message)
+        return HttpResponseBadRequest(content=six.text_type(brx))
+
+    batch_start_time = datetime.now()
 
     # Fire these WSGI requests, and collect the response for the same.
-    response = execute_requests(wsgi_requests)
+    try:
+        response = execute_requests(wsgi_requests)
+    except BadBatchRequest as brx:
+        return HttpResponseBadRequest(content=six.text_type(brx))
+
+    batch_end_time = datetime.now()
 
     # Evrything's done, return the response.
-    resp = HttpResponse(
-        content=json.dumps(response), content_type="application/json")
+    resp_kwargs = {
+        "content": json.dumps(response, cls=BytesEncoder),
+        "content_type": "application/json",
+        "status": _settings.BATCH_RESPONSE_STATUS,
+    }
+
+    # handle STDLIB unknown reason phrases
+    batch_reason = UNKNOWN_STATUSES.get(_settings.BATCH_RESPONSE_STATUS, None)
+    if batch_reason:
+        resp_kwargs["reason"] = batch_reason
+
+    resp = HttpResponse(**resp_kwargs)
+
+    if _settings.DISALLOW_CACHING:
+        resp["Cache-Control"] = "Private"
 
     if _settings.ADD_DURATION_HEADER:
-        resp.__setitem__(_settings.DURATION_HEADER_NAME, str((datetime.now() - batch_start_time).seconds))
+        resp[DURATION_HEADER_NAME] = construct_duration_header(batch_end_time - batch_start_time)
+
+    if settings.DEBUG:
+        resp[_settings.DEBUG_HEADER_NAME] = json.dumps(_settings.as_dict(), cls=SetEncoder)
+
     return resp

--- a/batch_requests/views.py
+++ b/batch_requests/views.py
@@ -10,6 +10,7 @@ import logging
 from datetime import datetime
 
 import six
+from concurrent.futures import TimeoutError
 from django.conf import settings
 from django.http.response import (
     HttpResponse,
@@ -17,13 +18,11 @@ from django.http.response import (
     HttpResponseNotFound,
     HttpResponseServerError,
 )
-from django.template.response import ContentNotRenderedError
 from django.urls import resolve
 from django.urls.exceptions import Resolver404
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
-from batch_requests.concurrent.executor import TimeoutError
 from batch_requests.exceptions import BadBatchRequest
 from batch_requests.settings import br_settings as _settings
 from batch_requests.utils import get_wsgi_request_object
@@ -121,7 +120,7 @@ def get_response(wsgi_request):
     d_resp = {
         "status_code": resp.status_code,
         "reason_phrase": handle_sub_reason_phrase(resp),
-        "headers": {k:v for k, v in six.itervalues(resp._headers)},
+        "headers": {k: v for k, v in six.itervalues(resp._headers)},
         "body": handle_sub_response_body(resp),
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,16 @@
-Django==1.7.6
+# app
+Django<2.0
+futures==3.2.0
+
+# test
+coveralls==0.5
+pytest-cov==1.8.1
+py==1.4.26
+pytest==2.6.4
+pytest-django==2.8.0
+
+# dev
 flake8==2.4.0
 mccabe==0.3
 pep8==1.5.7
-py==1.4.26
 pyflakes==0.8.1
-pytest==2.6.4
-pytest-django==2.8.0
-coveralls==0.5
-pytest-cov==1.8.1
-futures==3.0.5

--- a/runtests.py
+++ b/runtests.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
         pytest_args = PYTEST_ARGS[style]
 
     if run_tests:
-	print("Running tests...")
+        print("Running tests...")
         exit_on_failure(pytest.main(pytest_args))
     if run_flake8:
         exit_on_failure(flake8_main(FLAKE8_ARGS))

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 
 import os
+import subprocess
 import sys
 
 import batch_requests
 
-from setuptools import setup
 from setuptools import setup, Command
 
 class PyTest(Command):
@@ -21,8 +21,6 @@ class PyTest(Command):
         pass
 
     def run(self):
-        import subprocess
-        import sys
         errno = subprocess.call('py.test --cov-report html --cov batch_requests tests/', shell=True)
         raise SystemExit(errno)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+
+import six
+
+
+def ensure_text_content(response):
+    text = response.content
+    if isinstance(response.content, six.binary_type):
+        text = response.content.decode("utf-8")
+
+    response.text = text
+    return response

--- a/tests/test_bad_batch_request.py
+++ b/tests/test_bad_batch_request.py
@@ -8,6 +8,8 @@ import json
 
 from django.test import TestCase
 
+from tests import ensure_text_content
+
 
 class TestBadBatchRequest(TestCase):
 
@@ -25,51 +27,76 @@ class TestBadBatchRequest(TestCase):
         '''
             Make a batch request with invalid HTTP method.
         '''
-        resp = self.client.post("/api/v1/batch/", json.dumps([self._batch_request("select", "/views", "", {})]),
-                                content_type="application/json")
+        resp = ensure_text_content(
+            self.client.post(
+                "/api/v1/batch/",
+                json.dumps([self._batch_request("select", "/views", "", {})]),
+                content_type="application/json"
+            )
+        )
 
         self.assertEqual(resp.status_code, 400, "Method validation is broken!")
-        self.assertEqual(resp.content.lower(), "invalid request method.", "Method validation is broken!")
+        self.assertEqual(resp.text.lower(), "invalid request method.", "Method validation is broken!")
 
     def test_missing_http_method(self):
         '''
             Make a batch request without HTTP method.
         '''
-        resp = self.client.post("/api/v1/batch/", json.dumps([{"body": "/views"}]), content_type="application/json")
+        resp = ensure_text_content(
+            self.client.post(
+                "/api/v1/batch/",
+                json.dumps([{"body": "/views"}]),
+                content_type="application/json"
+            )
+        )
 
         self.assertEqual(resp.status_code, 400, "Method & URL validation is broken!")
-        self.assertEqual(resp.content.lower(), "request definition should have url, method defined.",
-                         "Method validation is broken!")
+        self.assertEqual(resp.text.lower(), "request definition should have url, method defined.", "Method validation is broken!")
 
     def test_missing_url(self):
         '''
             Make a batch request without the URL.
         '''
-        resp = self.client.post("/api/v1/batch/", json.dumps([{"method": "get"}]), content_type="application/json")
+        resp = ensure_text_content(
+            self.client.post(
+                "/api/v1/batch/",
+                json.dumps([{"method": "get"}]),
+                content_type="application/json"
+            )
+        )
 
         self.assertEqual(resp.status_code, 400, "Method & URL validation is broken!")
-        self.assertEqual(resp.content.lower(), "request definition should have url, method defined.",
+        self.assertEqual(resp.text.lower(), "request definition should have url, method defined.",
                          "Method validation is broken!")
 
     def test_invalid_batch_request(self):
         '''
             Make a batch request without wrapping in the list.
         '''
-        resp = self.client.post("/api/v1/batch/", json.dumps({"method": "get", "url": "/views/"}),
-                                content_type="application/json")
+        resp = ensure_text_content(
+            self.client.post(
+                "/api/v1/batch/",
+                json.dumps({"method": "get", "url": "/views/"}),
+                content_type="application/json"
+            )
+        )
 
-        print resp.content
         self.assertEqual(resp.status_code, 400, "Batch requests should always be in list.")
-        self.assertEqual(resp.content.lower(), "the body of batch request should always be list!",
+        self.assertEqual(resp.text.lower(), "the body of batch request should always be list!",
                          "List validation is broken!")
 
     def test_view_that_raises_exception(self):
         '''
             Make a batch request to a view that raises exception.
         '''
-        resp = self.client.post("/api/v1/batch/", json.dumps([{"method": "get", "url": "/exception/"}]),
-                                content_type="application/json")
+        resp = ensure_text_content(
+            self.client.post(
+                "/api/v1/batch/",
+                json.dumps([{"method": "get", "url": "/exception/"}]),
+                content_type="application/json"
+            )
+        )
 
-        resp = json.loads(resp.content)[0]
+        resp = json.loads(resp.text)[0]
         self.assertEqual(resp['status_code'], 500, "Exceptions should return 500.")
         self.assertEqual(resp['body'].lower(), "exception", "Exception handling is broken!")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,10 +3,15 @@
 
 @summary: Contains base test case for reusable test methods.
 '''
+from __future__ import unicode_literals
+
 import json
 
+import django
 from django.test import TestCase
+
 from batch_requests.settings import br_settings as settings
+from . import ensure_text_content
 
 
 class TestBase(TestCase):
@@ -24,6 +29,11 @@ class TestBase(TestCase):
         if settings.ADD_DURATION_HEADER:
             del batch_resp['headers'][settings.DURATION_HEADER_NAME]
 
+        # if Django >= 1.11, Content-Length header added
+        # TODO: fix this so we don't have to work around it
+        if django.VERSION >= (1, 11) and 'Content-Length' in ind_resp['headers']:
+            del ind_resp['headers']['Content-Length']
+
         self.assertDictEqual(ind_resp, batch_resp, "Compatibility is broken!")
 
     def headers_dict(self, headers):
@@ -36,25 +46,43 @@ class TestBase(TestCase):
         '''
             Returns a dict of all the parameters.
         '''
-        return {"status_code": status_code, "body": body, "headers": self.headers_dict(headers)}
+        return {
+            "status_code": status_code,
+            "body": body,
+            "headers": self.headers_dict(headers)
+        }
 
     def _batch_request(self, method, path, data, headers={}):
         '''
             Prepares a batch request.
         '''
-        return {"url": path, "method": method, "headers": headers, "body": data}
+        return {
+            "url": path,
+            "method": method,
+            "headers": headers,
+            "body": data
+        }
 
     def make_a_batch_request(self, method, url, body, headers={}):
         '''
             Makes a batch request using django client.
         '''
-        return self.client.post("/api/v1/batch/", json.dumps([self._batch_request(method, url, body, headers)]),
-                                content_type="application/json")
+        return ensure_text_content(self.client.post(
+            "/api/v1/batch/",
+            json.dumps([self._batch_request(method, url, body, headers)]),
+            content_type="application/json"
+        ))
 
     def make_multiple_batch_request(self, requests):
         '''
             Makes multiple batch request using django client.
         '''
-        batch_requests = [self._batch_request(method, path, data, headers) for method, path, data, headers in requests]
-        return self.client.post("/api/v1/batch/", json.dumps(batch_requests),
-                                content_type="application/json")
+        batch_requests = [
+            self._batch_request(method, path, data, headers)
+            for method, path, data, headers in requests
+        ]
+        return ensure_text_content(self.client.post(
+            "/api/v1/batch/",
+            json.dumps(batch_requests),
+            content_type="application/json"
+        ))

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -6,6 +6,7 @@
 '''
 import json
 
+from tests import ensure_text_content
 from tests.test_base import TestBase
 
 
@@ -21,12 +22,12 @@ class TestCompatibility(TestBase):
             that both gives the same results.
         '''
         # Get the response for an individual request.
-        inv_req = self.client.get("/views/")
-        inv_resp = self.prepare_response(inv_req.status_code, inv_req.content, inv_req._headers)
+        inv_req = ensure_text_content(self.client.get("/views/"))
+        inv_resp = self.prepare_response(inv_req.status_code, inv_req.text, inv_req._headers)
 
         # Get the response for a batch request.
         batch_request = self.make_a_batch_request("GET", "/views/", "")
-        batch_resp = json.loads(batch_request.content)[0]
+        batch_resp = json.loads(batch_request.text)[0]
         del batch_resp["reason_phrase"]
 
         # Assert both individual request response and batch response are equal.
@@ -40,12 +41,12 @@ class TestCompatibility(TestBase):
         data = json.dumps({"text": "hello"})
 
         # Get the response for an individual request.
-        inv_req = self.client.post("/views/", data, content_type="text/plain")
-        inv_resp = self.prepare_response(inv_req.status_code, inv_req.content, inv_req._headers)
+        inv_req = ensure_text_content(self.client.post("/views/", data, content_type="text/plain"))
+        inv_resp = self.prepare_response(inv_req.status_code, inv_req.text, inv_req._headers)
 
         # Get the response for a batch request.
         batch_request = self.make_a_batch_request("POST", "/views/", data, {"content_type": "text/plain"})
-        batch_resp = json.loads(batch_request.content)[0]
+        batch_resp = json.loads(batch_request.text)[0]
         del batch_resp["reason_phrase"]
 
         # Assert both individual request response and batch response are equal.
@@ -59,12 +60,12 @@ class TestCompatibility(TestBase):
         data = json.dumps({"text": "hello"})
 
         # Get the response for an individual request.
-        inv_req = self.client.patch("/views/", data, content_type="text/plain")
-        inv_resp = self.prepare_response(inv_req.status_code, inv_req.content, inv_req._headers)
+        inv_req = ensure_text_content(self.client.patch("/views/", data, content_type="text/plain"))
+        inv_resp = self.prepare_response(inv_req.status_code, inv_req.text, inv_req._headers)
 
         # Get the response for a batch request.
         batch_request = self.make_a_batch_request("patch", "/views/", data, {"content_type": "text/plain"})
-        batch_resp = json.loads(batch_request.content)[0]
+        batch_resp = json.loads(batch_request.text)[0]
         del batch_resp["reason_phrase"]
 
         # Assert both individual request response and batch response are equal.
@@ -78,12 +79,12 @@ class TestCompatibility(TestBase):
         data = json.dumps({"text": "hello"})
 
         # Get the response for an individual request.
-        inv_req = self.client.post("/views/", data, content_type="text/plain")
-        inv_resp = self.prepare_response(inv_req.status_code, inv_req.content, inv_req._headers)
+        inv_req = ensure_text_content(self.client.post("/views/", data, content_type="text/plain"))
+        inv_resp = self.prepare_response(inv_req.status_code, inv_req.text, inv_req._headers)
 
         # Get the response for a batch request.
         batch_request = self.make_a_batch_request("POST", "/views/", data, {"CONTENT_TYPE": "text/plain"})
-        batch_resp = json.loads(batch_request.content)[0]
+        batch_resp = json.loads(batch_request.text)[0]
         del batch_resp["reason_phrase"]
 
         # Assert both individual request response and batch response are equal.
@@ -95,12 +96,12 @@ class TestCompatibility(TestBase):
             that both gives the same results.
         '''
         # Get the response for an individual request.
-        inv_req = self.client.delete("/views/")
-        inv_resp = self.prepare_response(inv_req.status_code, inv_req.content, inv_req._headers)
+        inv_req = ensure_text_content(self.client.delete("/views/"))
+        inv_resp = self.prepare_response(inv_req.status_code, inv_req.text, inv_req._headers)
 
         # Get the response for a batch request.
         batch_request = self.make_a_batch_request("delete", "/views/", "")
-        batch_resp = json.loads(batch_request.content)[0]
+        batch_resp = json.loads(batch_request.text)[0]
         del batch_resp["reason_phrase"]
 
         # Assert both individual request response and batch response are equal.
@@ -116,16 +117,16 @@ class TestCompatibility(TestBase):
         # Make GET, POST and PUT requests individually.
 
         # Get the response for an individual GET request.
-        inv_req = self.client.get("/views/")
-        inv_get = self.prepare_response(inv_req.status_code, inv_req.content, inv_req._headers)
+        inv_req = ensure_text_content(self.client.get("/views/"))
+        inv_get = self.prepare_response(inv_req.status_code, inv_req.text, inv_req._headers)
 
         # Get the response for an individual POST request.
-        inv_req = self.client.post("/views/", data, content_type="text/plain")
-        inv_post = self.prepare_response(inv_req.status_code, inv_req.content, inv_req._headers)
+        inv_req = ensure_text_content(self.client.post("/views/", data, content_type="text/plain"))
+        inv_post = self.prepare_response(inv_req.status_code, inv_req.text, inv_req._headers)
 
         # Get the response for an individual PUT request.
-        inv_req = self.client.patch("/views/", data, content_type="text/plain")
-        inv_put = self.prepare_response(inv_req.status_code, inv_req.content, inv_req._headers)
+        inv_req = ensure_text_content(self.client.patch("/views/", data, content_type="text/plain"))
+        inv_put = self.prepare_response(inv_req.status_code, inv_req.text, inv_req._headers)
 
         # Consolidate all the responses.
         indv_responses = [inv_get, inv_post, inv_put]
@@ -137,7 +138,7 @@ class TestCompatibility(TestBase):
 
         # Get the response for a batch request.
         batch_requests = self.make_multiple_batch_request([get_req, post_req, put_req])
-        batch_responses = json.loads(batch_requests.content)
+        batch_responses = json.loads(batch_requests.text)
 
         # Assert all the responses are compatible.
         for indv_resp, batch_resp in zip(indv_responses, batch_responses):

--- a/tests/test_concurrency_base.py
+++ b/tests/test_concurrency_base.py
@@ -4,9 +4,10 @@
 @summary: Contains base test case for concurrency related tests.
 '''
 import json
+from datetime import datetime
 
 from tests.test_base import TestBase
-from batch_requests.settings import br_settings
+from batch_requests.settings import br_settings as _settings
 
 
 class TestBaseConcurrency(TestBase):
@@ -19,11 +20,11 @@ class TestBaseConcurrency(TestBase):
             Change the concurrency settings.
         '''
         self.number_workers = 10
-        self.orig_executor = br_settings.executor
+        self.orig_executor = _settings.executor
 
     def tearDown(self):
         # Restore the original batch requests settings.
-        br_settings.executor = self.orig_executor
+        _settings.executor = self.orig_executor
 
     def compare_seq_and_concurrent_req(self):
         '''
@@ -42,14 +43,22 @@ class TestBaseConcurrency(TestBase):
 
         # FIXME: Find the better way to manage / update settings.
         # Update the settings.
-        br_settings.executor = self.get_executor()
+        _settings.executor = self.get_executor()
         threaded_batch_requests = self.make_multiple_batch_request([get_req, post_req, put_req])
 
-        seq_responses = json.loads(batch_requests.content)
-        conc_responses = json.loads(threaded_batch_requests.content)
+        seq_responses = json.loads(batch_requests.content.decode("utf-8"))
+        conc_responses = json.loads(threaded_batch_requests.content.decode("utf-8"))
 
         for idx, seq_resp in enumerate(seq_responses):
-            self.assertDictEqual(seq_resp, conc_responses[idx], "Sequential and concurrent response not same!")
+            conc_resp = conc_responses[idx]
+
+            # durations are now more finegrained, compare them separately
+            conc_duration = conc_resp["headers"].pop(_settings.DURATION_HEADER_NAME)
+            seq_duration = seq_resp["headers"].pop(_settings.DURATION_HEADER_NAME)
+
+            # using 10ms as a current error bounds on durations
+            assert abs(float(conc_duration) - float(seq_duration)) <= 0.010
+            assert seq_resp == conc_resp
 
     def compare_seq_concurrent_duration(self):
         '''
@@ -62,11 +71,15 @@ class TestBaseConcurrency(TestBase):
 
         # Get the response for a batch request.
         batch_requests = self.make_multiple_batch_request([sleep_2_seconds, sleep_1_second, sleep_2_seconds])
-        seq_duration = int(batch_requests._headers.get(br_settings.DURATION_HEADER_NAME)[1])
+        seq_duration = float(
+            batch_requests._headers.get(_settings.DURATION_HEADER_NAME)[1]
+        )
 
         # Update the executor settings.
-        br_settings.executor = self.get_executor()
+        _settings.executor = self.get_executor()
         concurrent_batch_requests = self.make_multiple_batch_request([sleep_2_seconds, sleep_1_second, sleep_2_seconds])
-        concurrency_duration = int(concurrent_batch_requests._headers.get(br_settings.DURATION_HEADER_NAME)[1])
+        concurrency_duration = float(
+            concurrent_batch_requests._headers.get(_settings.DURATION_HEADER_NAME)[1]
+        )
 
         self.assertLess(concurrency_duration, seq_duration, "Concurrent requests are slower than running them in sequence.")

--- a/tests/test_concurrency_base.py
+++ b/tests/test_concurrency_base.py
@@ -3,11 +3,12 @@
 
 @summary: Contains base test case for concurrency related tests.
 '''
-import json
-from datetime import datetime
+from __future__ import absolute_import, unicode_literals
 
-from tests.test_base import TestBase
+import json
+
 from batch_requests.settings import br_settings as _settings
+from tests.test_base import TestBase
 
 
 class TestBaseConcurrency(TestBase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,12 +1,15 @@
 '''
 @author: rahul
 '''
-import json
+from __future__ import unicode_literals
 
+import json
+from time import sleep
+
+import six
 from django.http.response import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
-from time import sleep
 
 
 class SimpleView(View):
@@ -35,7 +38,10 @@ class SimpleView(View):
         '''
         # Imaginary current view of data.
         data = {"method": "PUT", "status": 202, "text": "Updated"}
-        data.update(json.loads(request.body))
+        body = request.body
+        if isinstance(body, six.binary_type):
+            body = body.decode("utf-8")
+        data.update(json.loads(body))
         return HttpResponse(status=202, content=json.dumps(data))
 
     def patch(self, request):
@@ -44,7 +50,10 @@ class SimpleView(View):
         '''
         # Imaginary current view of data.
         data = {"method": "PUT", "status": 202, "text": "Updated"}
-        data.update(json.loads(request.body))
+        body = request.body
+        if isinstance(body, six.binary_type):
+            body = body.decode("utf-8")
+        data.update(json.loads(body))
         return HttpResponse(status=202, content=json.dumps(data))
 
     def delete(self, request):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from batch_requests.views import handle_batch_requests
 from tests.test_views import SimpleView, EchoHeaderView, ExceptionView,\
     SleepingView
 
 
-urlpatterns = patterns('',
-                       url(r'^views/', SimpleView.as_view()),
-                       url(r'^echo/', EchoHeaderView.as_view()),
-                       url(r'^exception/', ExceptionView.as_view()),
-                       url(r'^sleep/', SleepingView.as_view()),
-                       url(r'^api/v1/batch/', handle_batch_requests),
-                       )
+urlpatterns = [
+    url(r'^views/', SimpleView.as_view()),
+    url(r'^echo/', EchoHeaderView.as_view()),
+    url(r'^exception/', ExceptionView.as_view()),
+    url(r'^sleep/', SleepingView.as_view()),
+    url(r'^api/v1/batch/', handle_batch_requests),
+]


### PR DESCRIPTION
- Now compatible with Django 1.7, 1.8, 1.9, 1.10, and 1.11
- Mostly compatible with Django 2.0
- Adds several new features for O'Reilly use:
  - Custom batch response status code
  - Handles 404 sub-responses
  - Cleaned up implementation of concurrent executors
  - Cleaned up/refactored views and utils
  - Allows singly or doubly (previous) JSON encoded input bodies
  - Allows for deserialization of sub-responses, in order
    to remove doubly encoded responses in batch response
  - Adds timeout handling, with HTTP 408 status, for concurrent
    sub-requests

Refs: SPIDR-360